### PR TITLE
Fix README and lex file merge issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@
 
 ### Mostrar conjuntos:
   #### Sets;
-<<<<<<< HEAD
-=======
-  #### ShowsSets;
->>>>>>> 605012f (Correction Compilation Errors)
   #### ShowSets; (también se acepta ShowsSets)
 
 ### Operaciones entre conjuntos:
@@ -61,10 +57,6 @@
 #### Set Nom := {a,b,3xy};
 #### Set L := {a,b,c};
 #### Sets;
-<<<<<<< HEAD
-=======
-#### ShowsSets;
->>>>>>> 605012f (Correction Compilation Errors)
 #### ShowSets;
 #### (también se acepta ShowsSets)
 #### Union Nom,L;

--- a/conjuntos.l
+++ b/conjuntos.l
@@ -15,10 +15,6 @@ ClearSet                    { return SINGLE; }
 Delete                      { return SINGLE; }
 Union                       { return BIN; }
 interseccion|Interseccion   { return BIN; }
-<<<<<<< HEAD
-=======
-ShowsSets                   { return NONE; }
->>>>>>> 605012f (Correction Compilation Errors)
 ShowSets|ShowsSets          { return NONE; }
 ShowSet                     { return SINGLE; }
 Sets                        { return NONE; }
@@ -30,17 +26,9 @@ Set                         { return SET; }
 ";"                         { return PUNTOYCOMA; }
 ","                         { return COMMA; }
 
-<<<<<<< HEAD
 [a-zA-Z0-9]+                 {
                                yylval.str = strdup(yytext);
                                return VARIABLE;
-=======
-[a-zA-Z][a-zA-Z0-9]*        {
-[a-zA-Z0-9]+                 {
-                               yylval.str = strdup(yytext);
-                               return VARIABLE;
-                            }
->>>>>>> 605012f (Correction Compilation Errors)
                              }
 
 [ \t\r\n]+                  ;


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers from README
- fix merge artifacts in `conjuntos.l`
- simplify variable rule in lex file

## Testing
- `flex conjuntos.l` *(fails: command not found)*
- `bison -d parser.y` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865af8849d08330a2cb2762ce2a1e0f