### PR TITLE
Update lexer and docs for Intersection token

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@
 ### Operaciones entre conjuntos:
   #### Union Nom,L;
   #### Nom interseccion L;
-  #### También acepta la variación con Interseccion (con mayúscula)
+  #### También acepta la variación con Interseccion (con mayúscula) o Intersection en inglés
   #### Interseccion Nom,L;
+  #### Intersection Nom,L;
 
 ### Crear conjuntos nuevos con resultado de operación:
   #### SetUnion X,Nom,L;
@@ -51,6 +52,9 @@
 1. Ejecuta `flex conjuntos.l` para generar `lex.yy.c`.
 2. Ejecuta `bison -d parser.y` para generar `parser.tab.c` y `parser.tab.h`.
 3. Compila todo con `g++ lex.yy.c parser.tab.c -o analizador -lfl`.
+   Si el ejecutable `analizador` existente produce errores inesperados,
+   vuelve a compilarlo siguiendo los pasos anteriores para asegurarte de
+   que esté sincronizado con los archivos fuente.
 
 ### Luego escribe una entrada en el programa, por ejemplo: 
 

--- a/conjuntos.l
+++ b/conjuntos.l
@@ -14,7 +14,7 @@ SetUnion                    { return BIN; }
 ClearSet                    { return SINGLE; }
 Delete                      { return SINGLE; }
 Union                       { return BIN; }
-interseccion|Interseccion   { return BIN; }
+interseccion|Interseccion|Intersection   { return BIN; }
 ShowSets|ShowsSets          { return NONE; }
 ShowSet                     { return SINGLE; }
 Sets                        { return NONE; }
@@ -26,7 +26,7 @@ Set                         { return SET; }
 ";"                         { return PUNTOYCOMA; }
 ","                         { return COMMA; }
 
-[a-zA-Z0-9]+                 {
+[a-zA-Z_][a-zA-Z0-9_]*|[0-9]+ {
                                yylval.str = strdup(yytext);
                                return VARIABLE;
                              }


### PR DESCRIPTION
## Summary
- add `Intersection` alias to tokenizer
- allow leading underscore and pure digits in identifiers
- document `Intersection` token usage
- clarify that the binary might need recompilation if it misbehaves

## Testing
- `./analizador <<'EOF'
Set A := {a,b,c};
Set B := {1,2};
ShowSets;
A Union B;
Delete A;
Intersection A B;
EOF`

------
https://chatgpt.com/codex/tasks/task_e_6865b2f9e3e08330bc3934ba2cc8b774