### PR TITLE
Fix build with wrapper functions

### DIFF
--- a/src/semantica.h
+++ b/src/semantica.h
@@ -4,6 +4,9 @@
 #include <vector>
 #include <string>
 
+// Declaración de yylex para el parser generado por bison
+int yylex();
+
 // Funciones que el parser invoca
 void crearConjunto(const std::string& N, const std::vector<std::string>& elems);
 void hacerUnion(const std::string& A, const std::string& B);
@@ -19,6 +22,16 @@ void eliminarConjunto(const std::string& N);
 void listarConjuntos();
 void mostrarTodos();
 void mostrarConjunto(const std::string& N);
+
+// Compatibilidad con versiones antiguas del parser generadas por bison
+// que invocan estas funciones con otros nombres.
+inline void mostrarConjuntos()          { mostrarTodos(); }
+inline void realizarUnion(const std::string& A, const std::string& B) { hacerUnion(A, B); }
+inline void realizarInterseccion(const std::string& A, const std::string& B) { hacerInterseccion(A, B); }
+inline void realizarConcat(const std::string& A, const std::string& B) { hacerConcat(A, B); }
+inline void guardarResultadoUnion(const std::string& N, const std::string& A, const std::string& B) { guardarUnion(N, A, B); }
+inline void guardarResultadoInterseccion(const std::string& N, const std::string& A, const std::string& B) { guardarInterseccion(N, A, B); }
+inline void guardarResultadoConcat(const std::string& N, const std::string& A, const std::string& B) { guardarConcat(N, A, B); }
 
 #endif // SEMANTICA_H
 


### PR DESCRIPTION
## Summary
- provide `yylex` declaration in `semantica.h`
- add inline wrapper functions so old parser.c can link

## Testing
- `g++ -std=c++17 -I src lex.yy.c parser.tab.c src/*.cpp -o calculadora`

------
https://chatgpt.com/codex/tasks/task_e_6865db5ebca0833089a7214e781b5285