### PR TITLE
Fix missing include for cerr

### DIFF
--- a/conjuntos.l
+++ b/conjuntos.l
@@ -3,6 +3,7 @@
 #include "parser.tab.h"
 #include "token_stack.h"
 #include <string>
+#include <iostream>
 #define PUSH_TOKEN(x) gTokenStack.push(std::string(x))
 %}
 

--- a/lex.yy.c
+++ b/lex.yy.c
@@ -485,6 +485,7 @@ char *yytext;
 #include "parser.tab.h"
 #include "token_stack.h"
 #include <string>
+#include <iostream>
 #define PUSH_TOKEN(x) gTokenStack.push(std::string(x))
 #line 490 "lex.yy.c"
 #line 491 "lex.yy.c"


### PR DESCRIPTION
## Summary
- include `<iostream>` in Flex source and generated C

## Testing
- `g++ -std=c++17 -I src lex.yy.c parser.tab.c src/*.cpp -o calculadora`

------
https://chatgpt.com/codex/tasks/task_e_6865dd28049883308b20ecc538fbbe57